### PR TITLE
Remove mongo root user file

### DIFF
--- a/WIP-README.md
+++ b/WIP-README.md
@@ -24,19 +24,10 @@ MONGO_IP=172.19.199.3
 MONGO_PORT=27017
 ```
 
-- create mongo-root-user.js
+## restore database
 
-```js
-db.createUser({
-  user: "user",
-  pwd: "password",
-  roles: [
-    {
-      role: "readWrite",
-      db: "database",
-    },
-  ],
-});
+```sh
+script/restore_dev_db.sh
 ```
 
 ## Running containers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - .env
 
     volumes:
-      - ./mongo-root-user.js:/docker-entrypoint-initdb.d/mongo-root-user.js:ro
       - ./mongo-volume:/data/db
       - ./:/appdata
     ports:


### PR DESCRIPTION
## Summary
<!-- Summarize Changes -->
- mongo-root-user.js is no longer needed. was being used to create a db user every time the mongo container was built
- After restoring, the db user is also restored