### PR TITLE
Remove MAINTAINER from Dockerfile.api

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,8 +1,5 @@
 FROM python:3.8-slim
 
-MAINTAINER Scott Nicholas Hackman <snickhackman@gmail.com>
-
-
 RUN mkdir /appdata
 WORKDIR /appdata
 COPY . .


### PR DESCRIPTION
Story: No Associated Story

## Summary

Remove `MAINTAINER` from `Dockerfile.api`
