### PR TITLE
Fix: typing request_schemas.validate_request_body

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -60,7 +60,7 @@ def auth_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
             500 - otherwise
         """
         body = validate_request_body(AdminLoginSchema, request.json)
-        if type(body) == str:
+        if isinstance(body, str):
             return {"msg": "Login unsuccessful"}, 400
 
         email = body["email"]
@@ -105,7 +105,7 @@ def auth_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
           500 - otherwise
         """
         body = validate_request_body(AdminRegisterSchema, request.get_json())
-        if type(body) == str:
+        if isinstance(body, str):
             return {"msg": body}, 400
 
         if body["password"] != body["password_confirmation"]:

--- a/api/request_schemas.py
+++ b/api/request_schemas.py
@@ -1,7 +1,7 @@
 """
 Module for request body schemas and validation function
 """
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from marshmallow import Schema, fields, ValidationError
 
 
@@ -67,7 +67,7 @@ class AdminUpdateSchema(Schema):
     superUser = fields.Boolean()
 
 
-def validate_request_body(schema, body: Dict) -> Any:
+def validate_request_body(schema, body: Dict) -> Union[str, Dict[str, Any]]:
     """
     Validates a request body using the corresponding request schema
     """

--- a/api/resource/admin.py
+++ b/api/resource/admin.py
@@ -74,7 +74,7 @@ def admin_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
             500 - otherwise
         """
         body = validate_request_body(AdminInviteSchema, request.json)
-        if type(body) == str:
+        if isinstance(body, str):
             return {"msg": body}, 400
 
         if db.admins.find_one({"email": body["email"]}) is not None:
@@ -127,7 +127,7 @@ def admin_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
           500 - otherwise
         """
         body = validate_request_body(AdminUpdateSchema, request.json)
-        if type(body) == str:
+        if isinstance(body, str):
             return {"msg": body}, 400
 
         admin = db.admins.find_one({"email": body["email"]})

--- a/api/resource/culture.py
+++ b/api/resource/culture.py
@@ -125,7 +125,7 @@ def culture_routes(app: Flask, db: MongoClient) -> None:
           500 - otherwise
         """
         body = validate_request_body(CultureCreateSchema, request.get_json())
-        if type(body) == str:
+        if isinstance(body, str):
             return {"msg": body}, 400
 
         collection = db.cultures
@@ -184,7 +184,7 @@ def culture_routes(app: Flask, db: MongoClient) -> None:
           500 - otherwise
         """
         body = validate_request_body(CultureUpdateSchema, request.get_json())
-        if type(body) == str:
+        if isinstance(body, str):
             return {"msg": body}, 400
 
         result = db.cultures.replace_one({"name": name}, body)


### PR DESCRIPTION
Story: Not associated with a story

## Summary

The reason it disliked the `Union[str, Dict[str, Any]]` was because Mypy
didn't properly understand the type check when using `type(body) ==
str`, but does understand it when using `isinstance(body, str)`.

That's almost certainly a bug in Mypy.
