### PR TITLE
Form Validation -- Login/Register rewrite

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -1,7 +1,6 @@
 """module for Authentication and Authorization Routes."""
 from datetime import timedelta
-from json import dumps
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 
 from flask import Flask, request
 from flask_bcrypt import Bcrypt  # type: ignore
@@ -84,7 +83,7 @@ def auth_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
 
     @app.route("/v1/register", methods=["POST"])
     @jwt_required
-    def register() -> Tuple[Dict[str, str], int]:
+    def register() -> Tuple[Dict[str, Any], int]:
         """Register a new administrator.
 
         JWT is passed via

--- a/api/auth.py
+++ b/api/auth.py
@@ -146,7 +146,7 @@ def auth_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
 
         return (
             {
-                "user": dumps(body),
+                "user": body,
                 "token": create_access_token(
                     identity=body["email"], expires_delta=timedelta(days=1)
                 ),

--- a/api/auth.py
+++ b/api/auth.py
@@ -41,7 +41,14 @@ def auth_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
         Returns:
           200 - Oauth token
 
-          {"token": JWT}
+          {
+            "token": JWT,
+            "user": {
+              "name": "name",
+              "email": "test@gmail.com",
+              "superUser": false
+            }
+          }
 
           400 - malformed request body
           401 - wrong password
@@ -62,11 +69,15 @@ def auth_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
         if not bcrypt.check_password_hash(admin["password"], password):
             return {"msg": "Invalid username or password"}, 401
 
+        admin["_id"] = str(admin["_id"])
+        del admin["password"]
+
         return (
             {
                 "token": create_access_token(
                     identity=email, expires_delta=timedelta(days=1)
-                )
+                ),
+                "user": admin,
             },
             200,
         )
@@ -91,7 +102,14 @@ def auth_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
         Returns:
           200 - New admin created
 
-          {"token": JWT}
+          {
+            "token": JWT,
+            "user": {
+              "name": "name",
+              "email": "test@gmail.com",
+              "superUser": false
+            }
+          }
 
           400 - Malformed body
           401 - unauthorized

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -31,7 +31,14 @@ def test_login(client):
         "/v1/login", json={"email": "tester@gmail.com", "password": "password"}
     )
     assert res.status_code == 200
-    assert res.get_json()["token"] is not None
+    json = res.get_json()
+    assert json["token"] is not None
+    admin = json["user"]
+
+    assert admin["_id"] is not None
+
+    del admin["_id"]
+    assert admin == {"name": "tester", "email": "tester@gmail.com", "superUser": False}
 
 
 def test_login_invalid_bad_password(client):
@@ -71,7 +78,14 @@ def test_create_admin(client):
         },
     )
     assert res.status_code == 201
-    assert res.get_json()["token"] is not None
+    json = res.get_json()
+    assert json["token"] is not None
+
+    admin = json["user"]
+    assert admin["_id"] is not None
+    del admin["_id"]
+
+    assert admin == {"name": "tester", "email": "tester@gmail.com", "superUser": False}
 
 
 def test_create_admin_invalid_400(client):

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -8,7 +8,7 @@ import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
 import { registerRootComponent } from "expo";
 
-import { Home, Login, CultureView, EditInsight } from "./views";
+import { Home, Login, CultureView, EditInsight, Register } from "./views";
 
 import { Routes } from "./routes";
 import { Theme } from "./constants";
@@ -40,7 +40,7 @@ function App() {
             />
             <Stack.Screen name="Home" component={Home} />
             <Stack.Screen name="Login" component={Login} />
-            <Stack.Screen name="Register" component={Login} />
+            <Stack.Screen name="Register" component={Register} />
             <Stack.Screen name="EditInsight" component={EditInsight} />
           </Stack.Navigator>
         </NavigationContainer>

--- a/frontend/api/admin.ts
+++ b/frontend/api/admin.ts
@@ -1,6 +1,14 @@
 import { Api } from "./api";
 
 /**
+ * Payload returned by {@link Admin.login} and {@link Admin.create}
+ */
+export type AuthPayload = {
+  user: Admin;
+  token: string;
+};
+
+/**
  * Administrator wrapper around fetch for interacting with API.
  */
 export class Admin {
@@ -39,11 +47,11 @@ export class Admin {
    *
    * @param {string} email - email of Admin
    * @param {string} password - password of Admin
-   * @returns {Promise<string>} JSON Web Token authenticating the admin
+   * @returns {Promise<AuthPayload>} JWT token and Admin user information
    */
-  static async login(email: string, password: string): Promise<string> {
+  static async login(email: string, password: string): Promise<AuthPayload> {
     const json = await Api.post("/login", { email: email, password: password });
-    return json["token"];
+    return json;
   }
 
   /**
@@ -125,7 +133,7 @@ export class Admin {
    * @param {string} password - password validation
    * @param {string} passwordConfirmation - MUST match password
    * @param {string} token - JSON Web Token
-   * @returns {Promise<void>}
+   * @returns {Promise<AuthPayload>} contains JSON Web Token and user information
    */
   static async create(
     name: string,
@@ -133,8 +141,8 @@ export class Admin {
     password: string,
     passwordConfirmation: string,
     token: string
-  ): Promise<void> {
-    await Api.post(
+  ): Promise<AuthPayload> {
+    const json = await Api.post(
       "/register",
       {
         name: name,
@@ -144,5 +152,7 @@ export class Admin {
       },
       token
     );
+
+    return json;
   }
 }

--- a/frontend/api/index.ts
+++ b/frontend/api/index.ts
@@ -1,4 +1,4 @@
-import { Admin } from "./admin";
+import { Admin, AuthPayload } from "./admin";
 import {
   GeneralInsight,
   Culture,
@@ -12,9 +12,10 @@ import { ApiError, OfflineError } from "./api";
 
 export {
   Admin,
+  AuthPayload,
+  ApiError,
   Culture,
   Ledger,
-  ApiError,
   OfflineError,
   GeneralInsight,
   SpecializedInsight,

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -1,4 +1,5 @@
 import { DefaultTheme } from "react-native-paper";
+import * as Yup from "yup";
 
 export const API_URL = "http://localhost:5000/v1";
 
@@ -10,3 +11,13 @@ export const Theme = {
     accent: "#1e88e5",
   },
 };
+/**
+ * Login Validation Schema, a Yup Schema for basic validation for Login not nearly as extensive as Register,
+ * but performs basic validation.
+ */
+export const LoginValidationSchema = Yup.object().shape({
+  // Email must be provided and be a valid email.
+  email: Yup.string().email("Invalid email address").required("Required"),
+  // Password must be provided
+  password: Yup.string().required("Required"),
+});

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -11,6 +11,7 @@ export const Theme = {
     accent: "#1e88e5",
   },
 };
+
 /**
  * Login Validation Schema, a Yup Schema for basic validation for Login not nearly as extensive as Register,
  * but performs basic validation.
@@ -21,3 +22,47 @@ export const LoginValidationSchema = Yup.object().shape({
   // Password must be provided
   password: Yup.string().required("Required"),
 });
+
+/**
+ * HelpText to displayed when a field is focused
+ * in the {@link Register} screen
+ */
+export const RegisterHelpText = {
+  name:
+    "This is how other administrators will see you. You can always change this later.",
+  email: "You'll need to verify that you own this email account.",
+  password:
+    "Strong passwords include a mix of lower case letters, uppercase letters, numbers, and special characters.",
+  passwordConfirmation: "Double check you know the password",
+};
+
+/**
+ * Register Validation Schema, a Yup Schema for basic validation
+ * for Account Registration.
+ */
+export const RegisterValidationSchema = Yup.object().shape({
+  // Name must be provided and be at least 2 characters
+  // up to 64 characters in length.
+  name: Yup.string()
+    .min(2, "Too short")
+    .max(64, "Too long")
+    .required("Required"),
+  // Email must be provided and be a valid email.
+  email: Yup.string().email("Invalid email address").required("Required"),
+  // Password must contain a lowercase, uppercase, one number, and a special character.
+  // Be at least 8 characters long and 64 maximum.
+  password: Yup.string()
+    .required("Required")
+    .min(8, "Must be at least 8 characters")
+    .max(64, "Too long")
+    .matches(
+      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]/,
+      "Must contain at least one uppercase letter, one lowercase letter, one number and one special character"
+    ),
+  // Password Confirmation must match Password
+  passwordConfirmation: Yup.string()
+    .required("Required")
+    .oneOf([Yup.ref("password"), null], "Must match password"),
+});
+
+export const TermsOfServiceURL = "http://www.google.com";

--- a/frontend/redux/UserAction.tsx
+++ b/frontend/redux/UserAction.tsx
@@ -1,4 +1,6 @@
-export const updateUser = (user) => ({
+import { Store } from "./UserReducer";
+
+export const updateUser = (user: Store["user"]) => ({
   type: "UPDATE_USER",
   payload: user,
 });

--- a/frontend/redux/UserReducer.tsx
+++ b/frontend/redux/UserReducer.tsx
@@ -6,7 +6,10 @@ const INITIAL_STATE = { user: { ...defaultAdmin }, token: "" };
 
 export type Store = { user: { user: Admin; token: string } };
 
-const userReducer = (state = INITIAL_STATE, action) => {
+const userReducer = (
+  state = INITIAL_STATE,
+  action: { type: string; payload: any }
+) => {
   switch (action.type) {
     case "UPDATE_USER":
       return { ...action.payload };

--- a/frontend/routes.ts
+++ b/frontend/routes.ts
@@ -23,5 +23,10 @@ export type Routes = {
   EditInsight: { culture: Culture; index: number | [string, number] };
   Home: undefined;
   Register: { token: string };
-  Login: { token: undefined };
+
+  /**
+   * Allows admin Login, Account recovery, and remembering the user's
+   * email between logins.
+   */
+  Login: undefined;
 };

--- a/frontend/views/Login.tsx
+++ b/frontend/views/Login.tsx
@@ -1,184 +1,238 @@
-import React, { useState } from "react";
-import { LinearGradient } from "expo-linear-gradient";
-import { Alert, View, StyleSheet } from "react-native";
-import { CommonActions } from "@react-navigation/native";
-import { Button, Card, TextInput, IconButton } from "react-native-paper";
-import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
-import { StackNavigationProp } from "@react-navigation/stack";
-import { RouteProp, useRoute } from "@react-navigation/native";
-import { Formik } from "formik";
+import React, { useState, useRef, useEffect } from "react";
 
-import { Admin } from "../api";
+import { View, StyleSheet } from "react-native";
+import {
+  Button,
+  TextInput,
+  HelperText,
+  Snackbar,
+  Checkbox,
+} from "react-native-paper";
+import { connect } from "react-redux";
+import { bindActionCreators, Dispatch } from "redux";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { CommonActions } from "@react-navigation/native";
+import { RouteProp } from "@react-navigation/native";
+import { useFormik } from "formik";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import { Admin, AuthPayload } from "../api";
 import { updateUser } from "../redux/UserAction";
 import { Routes } from "../routes";
+import { Store } from "../redux/UserReducer";
+import { LoginValidationSchema } from "../constants";
 
 type Props = {
-  navigation: StackNavigationProp<Routes, "Login" | "Register">;
-  route: RouteProp<Routes, "Login" | "Register">;
-  updateUser: Function;
+  navigation: StackNavigationProp<Routes, "Login">;
+  route: RouteProp<Routes, "Login">;
+  updateUser: (user: Store["user"]) => void;
 };
 
-const styles = StyleSheet.create({
-  card: {
-    marginTop: 100,
-    marginLeft: 20,
-    marginRight: 20,
-  },
-  container: {
-    padding: 10,
-    fontSize: 18,
-  },
+/**
+ * Login screen fields for Formik.
+ */
+type LoginFields = {
+  email: string;
+  password: string;
+};
+
+/**
+ * Initial values for Login fields for Formik.
+ */
+const initialValues: LoginFields = {
+  // This field could be updated with useEffect to enter the user's saved email address.
+  email: "",
+  password: "",
+};
+
+// Used for {@link AsyncStorage} to store a user's email
+// locally on their device.
+const RememberedEmail = "@rememberedEmail";
+
+const Styles = StyleSheet.create({
   view: {
-    height: "100%",
     flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
+    justifyContent: "space-evenly",
+    margin: 15,
+    overflow: "hidden",
   },
-  gradient: {
+
+  recover: {
     position: "absolute",
-    left: 0,
-    right: 0,
-    top: 0,
-    height: "100%",
+    bottom: 5,
   },
 });
 
-type RegistrationFields = {
-  name?: string;
-  email: string;
-  password: string;
-  passwordConfirmation?: string;
-};
-
+/**
+ * Screen for logging in an Admin
+ *
+ * @param {Props} props - properties for Login screen
+ *
+ * @returns {React.ReactElement} React Component
+ */
 function Login(props: Props): React.ReactElement {
+  const [remember, setRemember] = useState(false);
+  const [snackbar, setSnackbar] = useState(false);
+  const [err, setErr] = useState("");
   const [obscurePass, SetObscurePass] = useState(true);
-  const route = useRoute();
-  const token = props.route.params ? props.route.params.token : "";
-  const { navigation, updateUser } = props;
 
-  const initialValues: RegistrationFields = {
-    name: "",
-    email: "",
-    password: "",
-    passwordConfirmation: "",
-  };
+  // useRefs for Formik Validation
+  const email = useRef();
+  const password = useRef();
 
-  const handleLogin = async (fields: RegistrationFields) => {
+  const {
+    values,
+    handleChange,
+    handleBlur,
+    errors,
+    touched,
+    handleSubmit,
+    setFieldValue,
+    validateField,
+  } = useFormik({
+    validationSchema: LoginValidationSchema,
+    initialValues: initialValues,
+    onSubmit: (values) => login(values),
+  });
+
+  useEffect(() => {
+    const getEmail = async () => {
+      const email = await AsyncStorage.getItem(RememberedEmail);
+      if (email) {
+        setFieldValue("email", email);
+        setRemember(true);
+      }
+    };
+
+    getEmail();
+  }, []);
+
+  /**
+   * login performs Api Login operation.
+   *
+   * Response:
+   *   valid credentials:
+   *     1. login
+   *     2. get token
+   *     3. Save Email if user selected "Remember Me"
+   *     4. redirect to "Home"
+   *   invalid: display Snackbar
+   *
+   * @param {LoginFields} values currently stored in the form
+   */
+  const login = async (fields: LoginFields) => {
     const { email, password } = fields;
-    try {
-      const token = await Admin.login(email, password);
-      const user = await Admin.get(email, token);
-      updateUser({ user: { ...user }, token });
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 1,
-          routes: [{ name: "Home" }],
-        })
-      );
-    } catch (error) {
-      console.error("Unsuccessful Login", error);
-      Alert.alert(
-        "Unsuccessful Login",
-        "Incorrect username or password",
-        [{ text: "OK", onPress: () => console.log("OK Pressed") }],
-        { cancelable: true }
-      );
-    }
-  };
+    const { navigation, updateUser } = props;
 
-  const handleRegistration = async (fields: RegistrationFields) => {
-    const { name, email, password, passwordConfirmation } = fields;
-    if (!token) {
-      // User shouldn't be here, they don't have a token
-      props.navigation.navigate("Home");
+    let res: AuthPayload;
+    try {
+      res = await Admin.login(email, password);
+    } catch (err) {
+      setSnackbar(true);
+      setErr(err.toString());
       return;
     }
 
     try {
-      await Admin.create(name, email, password, passwordConfirmation, token);
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 1,
-          routes: [{ name: "Login" }],
-        })
-      );
-    } catch (error) {
-      console.error("Unsuccessful Registration", error);
-      Alert.alert(
-        "Unsuccessful Registration",
-        "helpful error message",
-        [{ text: "OK", onPress: () => console.log("OK Pressed") }],
-        { cancelable: true }
-      );
+      if (remember) {
+        await AsyncStorage.setItem(RememberedEmail, email);
+      } else {
+        await AsyncStorage.removeItem(RememberedEmail);
+      }
+    } catch (err) {
+      console.error("Failed to set Remembered Email", err);
+    }
+
+    updateUser(res);
+
+    navigation.dispatch(
+      CommonActions.reset({ index: 1, routes: [{ name: "Home" }] })
+    );
+  };
+
+  /**
+   * recoverAccount checks to see if the provided Email is valid
+   * if it is send recovery email. Otherwise, display Snackbar.
+   */
+  const recoverAccount = async () => {
+    await validateField("email");
+    if (errors.email === undefined) {
+      console.log(`Send recovery email to ${values.email}`);
+    } else {
+      setSnackbar(true);
+      setErr("Account recovery requires a valid Email");
     }
   };
 
   return (
-    <View style={styles.view}>
-      <LinearGradient colors={["#454545", "#f0f4ef"]} style={styles.gradient}>
-        <Formik
-          initialValues={initialValues}
-          onSubmit={(values) =>
-            route.name === "Login"
-              ? handleLogin(values)
-              : handleRegistration(values)
+    <View style={Styles.view}>
+      <View>
+        <TextInput
+          autoFocus={true}
+          textContentType="emailAddress"
+          mode="outlined"
+          error={errors.email && touched.email}
+          left={<TextInput.Icon name="email" />}
+          label="email"
+          ref={email}
+          value={values.email}
+          onBlur={handleBlur("email")}
+          onChangeText={handleChange("email")}
+        />
+        {errors.email && touched.email && (
+          <HelperText type="error">{errors.email}</HelperText>
+        )}
+      </View>
+      <View>
+        <TextInput
+          mode="outlined"
+          label="password"
+          ref={password}
+          left={<TextInput.Icon name="lock" />}
+          secureTextEntry={obscurePass}
+          error={errors.password && touched.password}
+          onBlur={handleBlur("password")}
+          value={values.password}
+          onChangeText={handleChange("password")}
+          right={
+            <TextInput.Icon
+              name={obscurePass ? "eye" : "eye-off"}
+              onPress={() => SetObscurePass(!obscurePass)}
+            />
           }
-        >
-          {({ handleChange, handleSubmit, values }) => (
-            <Card style={styles.card}>
-              {route.name === "Register" && (
-                <TextInput
-                  style={styles.container}
-                  mode="outlined"
-                  label="name"
-                  value={values.name}
-                  onChangeText={handleChange("name")}
-                />
-              )}
-              <TextInput
-                style={styles.container}
-                mode="outlined"
-                label="email"
-                value={values.email}
-                onChangeText={handleChange("email")}
-              />
-              <TextInput
-                style={styles.container}
-                mode="outlined"
-                label="password"
-                secureTextEntry={obscurePass}
-                value={values.password}
-                onChangeText={handleChange("password")}
-                right={
-                  <TextInput.Icon
-                    name={obscurePass ? "eye" : "eye-off"}
-                    onPress={() => SetObscurePass(!obscurePass)}
-                  />
-                }
-              />
-              {route.name === "Register" && (
-                <TextInput
-                  style={styles.container}
-                  mode="outlined"
-                  label="password confirmation"
-                  secureTextEntry={true}
-                  value={values.passwordConfirmation}
-                  onChangeText={handleChange("passwordConfirmation")}
-                />
-              )}
-              <Button icon="login" mode="contained" onPress={handleSubmit}>
-                {route.name}
-              </Button>
-            </Card>
-          )}
-        </Formik>
-      </LinearGradient>
+        />
+        {errors.password && touched.password && (
+          <HelperText type="error">{errors.password}</HelperText>
+        )}
+      </View>
+      <Checkbox.Item
+        label="Remember me"
+        status={remember ? "checked" : "unchecked"}
+        onPress={() => setRemember(!remember)}
+      />
+      <Button mode="contained" onPress={handleSubmit}>
+        Log In
+      </Button>
+      <Button
+        style={Styles.recover}
+        mode="text"
+        onPress={recoverAccount}
+        uppercase={false}
+      >
+        Trouble logging in?
+      </Button>
+      <Snackbar
+        visible={snackbar}
+        onDismiss={() => setSnackbar(false)}
+        action={{ label: "Ok", onPress: () => setSnackbar(false) }}
+      >
+        {err}
+      </Snackbar>
     </View>
   );
 }
 
-const mapDispatchToProps = (dispatch) =>
+const mapDispatchToProps = (dispatch: Dispatch) =>
   bindActionCreators(
     {
       updateUser,

--- a/frontend/views/Login.tsx
+++ b/frontend/views/Login.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { LinearGradient } from "expo-linear-gradient";
 import { Alert, View, StyleSheet } from "react-native";
 import { CommonActions } from "@react-navigation/native";
-import { Button, Card, TextInput } from "react-native-paper";
+import { Button, Card, TextInput, IconButton } from "react-native-paper";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { StackNavigationProp } from "@react-navigation/stack";
@@ -52,6 +52,7 @@ type RegistrationFields = {
 };
 
 function Login(props: Props): React.ReactElement {
+  const [obscurePass, SetObscurePass] = useState(true);
   const route = useRoute();
   const token = props.route.params ? props.route.params.token : "";
   const { navigation, updateUser } = props;
@@ -124,7 +125,7 @@ function Login(props: Props): React.ReactElement {
               : handleRegistration(values)
           }
         >
-          {({ handleChange, handleBlur, handleSubmit, values }) => (
+          {({ handleChange, handleSubmit, values }) => (
             <Card style={styles.card}>
               {route.name === "Register" && (
                 <TextInput
@@ -146,9 +147,15 @@ function Login(props: Props): React.ReactElement {
                 style={styles.container}
                 mode="outlined"
                 label="password"
-                secureTextEntry={true}
+                secureTextEntry={obscurePass}
                 value={values.password}
                 onChangeText={handleChange("password")}
+                right={
+                  <TextInput.Icon
+                    name={obscurePass ? "eye" : "eye-off"}
+                    onPress={() => SetObscurePass(!obscurePass)}
+                  />
+                }
               />
               {route.name === "Register" && (
                 <TextInput

--- a/frontend/views/Login.tsx
+++ b/frontend/views/Login.tsx
@@ -56,6 +56,13 @@ function Login(props: Props): React.ReactElement {
   const token = props.route.params ? props.route.params.token : "";
   const { navigation, updateUser } = props;
 
+  const initialValues: RegistrationFields = {
+    name: "",
+    email: "",
+    password: "",
+    passwordConfirmation: "",
+  };
+
   const handleLogin = async (fields: RegistrationFields) => {
     const { email, password } = fields;
     try {
@@ -81,24 +88,28 @@ function Login(props: Props): React.ReactElement {
 
   const handleRegistration = async (fields: RegistrationFields) => {
     const { name, email, password, passwordConfirmation } = fields;
-    if (token) {
-      try {
-        await Admin.create(name, email, password, passwordConfirmation, token);
-        navigation.dispatch(
-          CommonActions.reset({
-            index: 1,
-            routes: [{ name: "Login" }],
-          })
-        );
-      } catch (error) {
-        console.error("Unsuccessful Registration", error);
-        Alert.alert(
-          "Unsuccessful Registration",
-          "helpful error message",
-          [{ text: "OK", onPress: () => console.log("OK Pressed") }],
-          { cancelable: true }
-        );
-      }
+    if (!token) {
+      // User shouldn't be here, they don't have a token
+      props.navigation.navigate("Home");
+      return;
+    }
+
+    try {
+      await Admin.create(name, email, password, passwordConfirmation, token);
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 1,
+          routes: [{ name: "Login" }],
+        })
+      );
+    } catch (error) {
+      console.error("Unsuccessful Registration", error);
+      Alert.alert(
+        "Unsuccessful Registration",
+        "helpful error message",
+        [{ text: "OK", onPress: () => console.log("OK Pressed") }],
+        { cancelable: true }
+      );
     }
   };
 
@@ -106,12 +117,7 @@ function Login(props: Props): React.ReactElement {
     <View style={styles.view}>
       <LinearGradient colors={["#454545", "#f0f4ef"]} style={styles.gradient}>
         <Formik
-          initialValues={{
-            name: "",
-            email: "",
-            password: "",
-            passwordConfirmation: "",
-          }}
+          initialValues={initialValues}
           onSubmit={(values) =>
             route.name === "Login"
               ? handleLogin(values)

--- a/frontend/views/Register.tsx
+++ b/frontend/views/Register.tsx
@@ -1,0 +1,269 @@
+import React, { useState, useRef } from "react";
+
+import { View, StyleSheet, Linking } from "react-native";
+import {
+  Button,
+  TextInput,
+  HelperText,
+  Snackbar,
+  Text,
+} from "react-native-paper";
+import { connect } from "react-redux";
+import { bindActionCreators, Dispatch } from "redux";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { CommonActions } from "@react-navigation/native";
+import { RouteProp } from "@react-navigation/native";
+import { useFormik } from "formik";
+
+import { Admin, AuthPayload } from "../api";
+import { updateUser } from "../redux/UserAction";
+import { Routes } from "../routes";
+import { Store } from "../redux/UserReducer";
+import {
+  RegisterHelpText,
+  RegisterValidationSchema,
+  TermsOfServiceURL,
+} from "../constants";
+
+type Props = {
+  navigation: StackNavigationProp<Routes, "Register">;
+  route: RouteProp<Routes, "Register">;
+  updateUser: (user: Store["user"]) => void;
+};
+
+/**
+ * Register screen fields for Formik.
+ */
+type RegisterFields = {
+  name: string;
+  email: string;
+  password: string;
+  passwordConfirmation: string;
+};
+
+/**
+ * Initial values for Register fields for Formik.
+ */
+const initialValues: RegisterFields = {
+  name: "",
+  email: "",
+  password: "",
+  passwordConfirmation: "",
+};
+
+const Styles = StyleSheet.create({
+  view: {
+    flex: 1,
+    justifyContent: "space-evenly",
+    margin: 15,
+    overflow: "hidden",
+  },
+  link: {
+    color: "blue",
+    fontWeight: "bold",
+  },
+});
+
+type Focusable = "name" | "email" | "password" | "passwordConfirmation" | null;
+
+/**
+ * Screen for registering an Admin
+ *
+ * @param {Props} props - properties for Register screen
+ *
+ * @returns {React.ReactElement} React Component
+ */
+function Register(props: Props): React.ReactElement {
+  const token = props.route.params ? props.route.params.token : "";
+
+  const [obscurePass, SetObscurePass] = useState(true);
+  const [obscurePassConf, SetObscurePassConf] = useState(true);
+  const [snackbar, setSnackbar] = useState(false);
+  const [err, setErr] = useState("");
+  const [focused, setFocused] = useState<Focusable>("email");
+
+  const name = useRef();
+  const email = useRef();
+  const password = useRef();
+  const passwordConfirmation = useRef();
+
+  const {
+    values,
+    handleChange,
+    handleBlur,
+    errors,
+    touched,
+    handleSubmit,
+  } = useFormik({
+    validationSchema: RegisterValidationSchema,
+    initialValues: initialValues,
+    onSubmit: (values) => register(values),
+  });
+
+  /**
+   * Registers an Admin
+   *
+   * @param {RegisterFields} fields - input fields
+   */
+  const register = async (fields: RegisterFields) => {
+    const { name, email, password, passwordConfirmation } = fields;
+    const { navigation, updateUser } = props;
+
+    let res: AuthPayload;
+    try {
+      res = await Admin.create(
+        name,
+        email,
+        password,
+        passwordConfirmation,
+        token
+      );
+    } catch (err) {
+      setSnackbar(true);
+      setErr(err.toString());
+      return;
+    }
+
+    updateUser(res);
+
+    navigation.dispatch(
+      CommonActions.reset({ index: 1, routes: [{ name: "Home" }] })
+    );
+  };
+
+  /**
+   * Helper Text displays for {@link TextInput} if the field
+   * has an error then the error is showed. If it is focused without error information about the field is shown.
+   *
+   * @param {{fieldName: Focusable}} props - name of field
+   *
+   * @returns {React.ReactElement} React Component
+   */
+  const DisplayErrOrHelp = (props: {
+    fieldName: Focusable;
+  }): React.ReactElement => {
+    const { fieldName } = props;
+
+    if (focused !== fieldName && (!errors[fieldName] || !touched[fieldName])) {
+      return null;
+    }
+
+    if (errors[fieldName] && touched[fieldName]) {
+      return <HelperText type="error">{errors[fieldName]}</HelperText>;
+    } else {
+      return <HelperText type="info">{RegisterHelpText[fieldName]}</HelperText>;
+    }
+  };
+
+  return (
+    <View style={Styles.view}>
+      <View>
+        <TextInput
+          autoFocus={true}
+          textContentType="emailAddress"
+          onFocus={() => setFocused("email")}
+          mode="outlined"
+          error={errors.email && touched.email}
+          left={<TextInput.Icon name="email" />}
+          label="email"
+          ref={email}
+          value={values.email}
+          onChangeText={handleChange("email")}
+          onBlur={handleBlur("email")}
+        />
+        <DisplayErrOrHelp fieldName="email" />
+      </View>
+      <View>
+        <TextInput
+          textContentType="name"
+          onFocus={() => setFocused("name")}
+          mode="outlined"
+          error={errors.name && touched.name}
+          left={<TextInput.Icon name="account" />}
+          label="name"
+          ref={name}
+          value={values.name}
+          onChangeText={handleChange("name")}
+          onBlur={handleBlur("name")}
+        />
+        <DisplayErrOrHelp fieldName="name" />
+      </View>
+      <View>
+        <TextInput
+          mode="outlined"
+          label="password"
+          onFocus={() => setFocused("password")}
+          ref={password}
+          left={<TextInput.Icon name="lock" />}
+          secureTextEntry={obscurePass}
+          error={errors.password && touched.password}
+          onBlur={handleBlur("password")}
+          value={values.password}
+          onChangeText={handleChange("password")}
+          right={
+            <TextInput.Icon
+              name={obscurePass ? "eye" : "eye-off"}
+              onPress={() => SetObscurePass(!obscurePass)}
+            />
+          }
+        />
+        <DisplayErrOrHelp fieldName="password" />
+      </View>
+      <View>
+        <TextInput
+          mode="outlined"
+          label="password confirmation"
+          onFocus={() => setFocused("passwordConfirmation")}
+          ref={passwordConfirmation}
+          left={<TextInput.Icon name="shield-lock" />}
+          secureTextEntry={obscurePassConf}
+          error={errors.passwordConfirmation && touched.passwordConfirmation}
+          onBlur={handleBlur("passwordConfirmation")}
+          value={values.passwordConfirmation}
+          onChangeText={handleChange("passwordConfirmation")}
+          right={
+            <TextInput.Icon
+              name={obscurePassConf ? "eye" : "eye-off"}
+              onPress={() => SetObscurePassConf(!obscurePassConf)}
+            />
+          }
+        />
+        <DisplayErrOrHelp fieldName="passwordConfirmation" />
+      </View>
+      <View>
+        <Text>
+          By clicking Register, you are indicating that you have read and
+          acknowledged the
+          <Text
+            onPress={() => Linking.openURL(TermsOfServiceURL)}
+            style={Styles.link}
+          >
+            {" "}
+            Terms of Service
+          </Text>
+          .
+        </Text>
+      </View>
+      <Button mode="contained" onPress={handleSubmit}>
+        Register
+      </Button>
+      <Snackbar
+        visible={snackbar}
+        onDismiss={() => setSnackbar(false)}
+        action={{ label: "Ok", onPress: () => setSnackbar(false) }}
+      >
+        {err}
+      </Snackbar>
+    </View>
+  );
+}
+
+const mapDispatchToProps = (dispatch: Dispatch) =>
+  bindActionCreators(
+    {
+      updateUser,
+    },
+    dispatch
+  );
+
+export default connect(null, mapDispatchToProps)(Register);

--- a/frontend/views/index.ts
+++ b/frontend/views/index.ts
@@ -1,6 +1,7 @@
 import CultureView from "./Culture";
 import Login from "./Login";
+import Register from "./Register";
 import Home from "./Home";
 import EditInsight from "./EditInsight";
 
-export { CultureView, Login, Home, EditInsight };
+export { CultureView, Login, Home, EditInsight, Register };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/pako": "^1.0.1",
     "@types/react-native": "^0.63.30",
     "@types/react-redux": "^7.1.11",
+    "@types/yup": "^0.29.9",
     "expo": "~39.0.2",
     "expo-status-bar": "~1.0.2",
     "formik": "^2.2.5",
@@ -31,7 +32,8 @@
     "react-native-tab-view": "^2.15.2",
     "react-native-web": "~0.13.7",
     "react-redux": "^7.2.2",
-    "redux": "^4.0.5"
+    "redux": "^4.0.5",
+    "yup": "^0.30.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react-redux": "^7.1.11",
     "expo": "~39.0.2",
     "expo-status-bar": "~1.0.2",
+    "formik": "^2.2.5",
     "pako": "^1.0.11",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2278,6 +2278,11 @@ deep-equal@^2.0.3:
     which-collection "^1.0.1"
     which-typed-array "^1.1.2"
 
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 deepmerge@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
@@ -2867,6 +2872,19 @@ foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
   integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
+
+formik@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.5.tgz#addf4ed7a15ebddf22c883a3d358cd27c8a91a55"
+  integrity sha512-KkOsyYmh5xsow+wlbdL9QSkqvbiHSb1RIToBKiooCFW4lyypn+ZlHGjTuuOqUWBqZaI5nCEupeI275Mo6tFBzg==
+  dependencies:
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.14"
+    lodash-es "^4.17.14"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -3652,6 +3670,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash-es@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
@@ -4677,6 +4700,11 @@ react-dom@16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
 react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -5471,6 +5499,11 @@ tiny-queue@^0.2.1:
   resolved "https://registry.yarnpkg.com/tiny-queue/-/tiny-queue-0.2.1.tgz#25a67f2c6e253b2ca941977b5ef7442ef97a6046"
   integrity sha1-JaZ/LG4lOyypQZd7XvdELvl6YEY=
 
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -5517,6 +5550,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+tslib@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 type-fest@^0.7.1:
   version "0.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,7 +958,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.12.1", "@babel/runtime@^7.8.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -1407,6 +1407,11 @@
   integrity sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@types/yup@^0.29.9":
+  version "0.29.9"
+  resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.29.9.tgz#e2015187ae5739fd3b791b3b7ab9094f2aa5a474"
+  integrity sha512-ZtjjlrHuHTYctHDz3c8XgInjj0v+Hahe32N/4cDa2banibf9w6aAgxwx0jZtBjKKzmGIU4NXhofEsBW1BbqrNg==
 
 "@unimodules/core@~5.5.1":
   version "5.5.1"
@@ -3671,7 +3676,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.14:
+lodash-es@^4.17.11, lodash-es@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
@@ -3681,7 +3686,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.0:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -4645,6 +4650,11 @@ prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+property-expr@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.4.tgz#37b925478e58965031bb612ec5b3260f8241e910"
+  integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -5551,6 +5561,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+
 tslib@^1.10.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -5983,3 +5998,14 @@ yargs@^15.1.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yup@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.30.0.tgz#427ee076abb1d7e01e747fb782801f7df252fb76"
+  integrity sha512-GX3vqpC9E+Ow0fmQPgqbEg7UV40XRrN1IOEgKF5v04v6T4ha2vBas/hu0thWgewk8L4wUEBLRO/EnXwYyP+p+A==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
+    lodash "^4.17.20"
+    lodash-es "^4.17.11"
+    property-expr "^2.0.4"
+    toposort "^2.0.2"


### PR DESCRIPTION
Story: [OCA-103](https://5911-capstone.atlassian.net/browse/OCA-103)

## Summary

When attempting to apply Form validation to the previous Login/Register all in one component it got a little hairy, and that was without extra functionality like account recovery (on the road map), "remember me" for login, displaying Terms of Service, etc. It seemed like a good idea to split the pages up so they are now two separate pages that are all validated.

- Feat: Login/Register use Formik for forms
- Feat: Formik handleSubmit pass fields
- Feat: Login/Register Password view password
- Feat: Api Login and Admin Create return info
- Fix: Improve type information for Redux operations
- Deps: Add Yup and @types/yup
- Feat: Revamp login screen
- Feat: Register Page

## Screenshot(s)

### Sign up page

Whenever you focus a input if there are no errors it'll tell you the importance of the field. Currently the Terms of Service link redirects to Google, because sure why not. It still feels like it needs something else, like a password strength checker or whatever, but that's for another day.


![windowshot-11-22-2020-08:32:49 PM](https://user-images.githubusercontent.com/31719071/99923226-cf895300-2d02-11eb-86cc-16fa7c984adc.png)

### Sign in page

Basic validation on this one, just checking to see if the email is valid and password is not empty. Remember me uses `Asyncstorage` in order to fetch and set the user's email in between sessions. Should help for both development and user experience, I'm tired of typing my email over and over again. "Trouble logging in" button doesn't do much of anything other than validate that the `email` field is valid and console log it. The rest of this will be complete by the account recovery story.

![windowshot-11-22-2020-04:38:44 PM](https://user-images.githubusercontent.com/31719071/99923265-f051a880-2d02-11eb-8841-e0c055cbcd22.png)

<!--- Don't forget to request a reviewer -->
