### PR TITLE
Rename Api Routes Last Time for Version 1

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -17,35 +17,7 @@ def create_app() -> Flask:
     """
     app = Flask(__name__)
 
-    @app.route("/")
-    def index() -> Dict[str, List[Dict[str, Any]]]:
-        """Index that informs user about routes.
-
-        Returns:
-          200 - JSON containing all routes
-
-          {
-            "routes": [
-              {
-                "methods": [
-                  "POST",
-                  "OPTIONS"
-                ],
-                "url": "/v1/admin/invite"
-              },
-              ...
-            ]
-          }
-
-          500 - otherwise
-        """
-        response: Dict[str, List[Dict[str, Any]]] = {"routes": []}
-        for rule in app.url_map.iter_rules():
-            route = {"url": f"{rule.rule}", "methods": list(rule.methods)}
-            response["routes"].append(route)
-        return response
-
-    @app.route("/v1/health")
+    @app.route("/health")
     def health():
         """Health route."""
         return {"msg": "healthy"}

--- a/api/auth.py
+++ b/api/auth.py
@@ -27,7 +27,7 @@ def auth_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
     """
     jwt = JWTManager(app)
 
-    @app.route("/v1/login", methods=["POST"])
+    @app.route("/api/v1/login", methods=["POST"])
     def login() -> Tuple[Dict[str, str], int]:
         """Login a User.
 
@@ -71,7 +71,7 @@ def auth_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
             200,
         )
 
-    @app.route("/v1/register", methods=["POST"])
+    @app.route("/api/v1/register", methods=["POST"])
     @jwt_required
     def register() -> Tuple[Dict[str, str], int]:
         """Register a new administrator.

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -16,7 +16,7 @@ def login_admin(flask_client):
         flask_client: Flask test client
     """
     res = flask_client.post(
-        "/v1/login", json={"email": "admin@gmail.com", "password": "password"}
+        "/api/v1/login", json={"email": "admin@gmail.com", "password": "password"}
     )
 
     json = res.get_json()

--- a/api/resource/admin.py
+++ b/api/resource/admin.py
@@ -24,7 +24,7 @@ def admin_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
     bcrypt: Bcrypt handle
     """
 
-    @app.route("/v1/admin")
+    @app.route("/api/v1/admins")
     @jwt_required
     def admins() -> Dict[str, List[str]]:
         """List all admins.
@@ -41,7 +41,7 @@ def admin_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
         admins = [admin["email"] for admin in collection.find().sort("email")]
         return {"admins": admins}
 
-    @app.route("/v1/admin/<email>")
+    @app.route("/api/v1/admins/<email>")
     @jwt_required
     def admin(email: str) -> Tuple[Dict[str, str], int]:
         """Fetch information about an admin.
@@ -66,7 +66,7 @@ def admin_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
         del admin["_id"]
         return admin, 200
 
-    @app.route("/v1/admin/invite", methods=["POST"])
+    @app.route("/api/v1/admins/invite", methods=["POST"])
     @jwt_required
     def invite() -> Tuple[Dict[str, str], int]:
         """Invite admin via Email.
@@ -103,7 +103,7 @@ def admin_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
 
         return {"msg": f"email sent to {email}"}, 200
 
-    @app.route("/v1/admin/<email>", methods=["PUT"])
+    @app.route("/api/v1/admins/<email>", methods=["PUT"])
     @jwt_required
     def admin_update(email: str) -> Tuple[Dict[str, str], int]:
         """Update Admin.
@@ -157,7 +157,7 @@ def admin_routes(app: Flask, db: MongoClient, bcrypt: Bcrypt) -> None:
 
         return {"msg": f"successfully updated admin <{email}>"}, 200
 
-    @app.route("/v1/admin/<email>", methods=["DELETE"])
+    @app.route("/api/v1/admins/<email>", methods=["DELETE"])
     @jwt_required
     def admin_delete(email: str) -> Tuple[Dict[str, str], int]:
         """Delete Admin.

--- a/api/resource/culture.py
+++ b/api/resource/culture.py
@@ -19,7 +19,7 @@ def culture_routes(app: Flask, db: MongoClient) -> None:
     db: MongoDB client
     """
 
-    @app.route("/v1/culture")
+    @app.route("/api/v1/cultures")
     def cultures() -> Tuple[Dict[str, List[Dict[str, Any]]], int]:
         """Fetch a list of all culture groups in alphabetical order with their last modified timestamps.
 
@@ -41,7 +41,7 @@ def culture_routes(app: Flask, db: MongoClient) -> None:
         ]
         return {"cultures": cultures}, 200
 
-    @app.route("/v1/culture/<name>")
+    @app.route("/api/v1/cultures/<name>")
     def culture(name: str) -> Tuple[Dict[str, Any], int]:
         """Fetch information about a specific Culture Group.
 
@@ -60,7 +60,7 @@ def culture_routes(app: Flask, db: MongoClient) -> None:
         culture["_id"] = str(culture["_id"])
         return culture, 200
 
-    @app.route("/v1/culture", methods=["POST"])
+    @app.route("/api/v1/cultures", methods=["POST"])
     @jwt_required
     def culture_create() -> Tuple[Dict[str, str], int]:
         """Create a Culture with information.
@@ -102,7 +102,7 @@ def culture_routes(app: Flask, db: MongoClient) -> None:
         body["_id"] = str(body["_id"])
         return body, 201
 
-    @app.route("/v1/culture/<name>", methods=["PUT"])
+    @app.route("/api/v1/cultures/<name>", methods=["PUT"])
     @jwt_required
     def culture_update(name: str) -> Tuple[Dict[str, str], int]:
         """Update an existing Culture.
@@ -151,7 +151,7 @@ def culture_routes(app: Flask, db: MongoClient) -> None:
 
         return body, 200
 
-    @app.route("/v1/culture/<name>", methods=["DELETE"])
+    @app.route("/api/v1/cultures/<name>", methods=["DELETE"])
     @jwt_required
     def culture_delete(name: str) -> Tuple[Dict[str, str], int]:
         """Delete an existing Culture.

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -1,9 +1,9 @@
 def test_list_admins(client):
-    res = client.get("/v1/admin")
+    res = client.get("/api/v1/admins")
     assert res.get_json()["admins"] == ["admin@gmail.com"]
 
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -12,13 +12,13 @@ def test_list_admins(client):
         },
     )
 
-    res = client.get("/v1/admin")
+    res = client.get("/api/v1/admins")
     assert res.get_json()["admins"] == ["admin@gmail.com", "tester@gmail.com"]
 
 
 def test_login(client):
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -28,7 +28,7 @@ def test_login(client):
     )
 
     res = client.post(
-        "/v1/login", json={"email": "tester@gmail.com", "password": "password"}
+        "/api/v1/login", json={"email": "tester@gmail.com", "password": "password"}
     )
     assert res.status_code == 200
     assert res.get_json()["token"] is not None
@@ -36,33 +36,38 @@ def test_login(client):
 
 def test_login_invalid_bad_password(client):
     res = client.post(
-        "/v1/login", json={"email": "admin@gmail.com", "password": "not-the-password"}
+        "/api/v1/login",
+        json={"email": "admin@gmail.com", "password": "not-the-password"},
     )
     assert res.status_code == 401
 
 
 def test_login_invalid_bad_email(client):
     res = client.post(
-        "/v1/login", json={"email": "admins@gmail.com", "password": "not-the-password"}
+        "/api/v1/login",
+        json={"email": "admins@gmail.com", "password": "not-the-password"},
     )
     assert res.status_code == 401
 
 
 def test_login_invalid_400(client):
     res = client.post(
-        "/v1/login", json={"email": "admin@gmail.com", "passwordss": "not-the-password"}
+        "/api/v1/login",
+        json={"email": "admin@gmail.com", "passwordss": "not-the-password"},
     )
     assert res.status_code == 400
 
 
 def test_invalid_jwt(client):
-    res = client.get("v1/admin", headers={"Authorization": "Bearer " + "this-is-fake"})
+    res = client.get(
+        "/api/v1/admins", headers={"Authorization": "Bearer " + "this-is-fake"}
+    )
     assert res.status_code == 422
 
 
 def test_create_admin(client):
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -76,7 +81,7 @@ def test_create_admin(client):
 
 def test_create_admin_invalid_400(client):
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -89,7 +94,7 @@ def test_create_admin_invalid_400(client):
 
 def test_create_admin_invalid_password_and_confirm_dont_match(client):
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -102,7 +107,7 @@ def test_create_admin_invalid_password_and_confirm_dont_match(client):
 
 def test_create_admin_duplicate(client):
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -114,7 +119,7 @@ def test_create_admin_duplicate(client):
     assert res.status_code == 201
 
     res1 = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -131,7 +136,7 @@ def test_create_admin_duplicate(client):
 
 
 def test_get_admin(client):
-    res = client.get("/v1/admin/admin@gmail.com")
+    res = client.get("/api/v1/admins/admin@gmail.com")
     res.get_json() == {
         "name": "admin",
         "email": "admin@gmail.com",
@@ -139,14 +144,14 @@ def test_get_admin(client):
 
 
 def test_get_admin_invalid_no_admin(client):
-    res = client.get("/v1/admin/admins@gmail.com")
+    res = client.get("/api/v1/admins/admins@gmail.com")
     assert res.get_json()["msg"] == "unknown admin `admins@gmail.com`"
     assert res.status_code == 404
 
 
 def test_delete_admin(client):
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -154,13 +159,13 @@ def test_delete_admin(client):
             "password_confirmation": "password",
         },
     )
-    res = client.delete("/v1/admin/tester@gmail.com")
+    res = client.delete("/api/v1/admins/tester@gmail.com")
     assert res.get_json() == {"msg": "successfully deleted admin <tester@gmail.com>"}
 
 
 def test_update_admin(client):
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -170,7 +175,7 @@ def test_update_admin(client):
     )
 
     res = client.put(
-        "/v1/admin/tester@gmail.com",
+        "/api/v1/admins/tester@gmail.com",
         json={
             "name": "tester-different-name",
             "email": "tester@gmail.com",
@@ -181,13 +186,13 @@ def test_update_admin(client):
 
     assert res.get_json() == {"msg": "successfully updated admin <tester@gmail.com>"}
 
-    res = client.get("/v1/admin")
+    res = client.get("/api/v1/admins")
     assert res.get_json() == {"admins": ["admin@gmail.com", "tester@gmail.com"]}
 
 
 def test_update_admin_invalid_400(client):
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -197,7 +202,7 @@ def test_update_admin_invalid_400(client):
     )
 
     res = client.put(
-        "/v1/admin/tester@gmail.com",
+        "/api/v1/admins/tester@gmail.com",
         json={
             "names": "tester-different-name",
             "email": "tester@gmail.com",
@@ -211,7 +216,7 @@ def test_update_admin_invalid_400(client):
 
 def test_update_admin_invalid_password_and_confirm_dont_match(client):
     res = client.post(
-        "/v1/register",
+        "/api/v1/register",
         json={
             "name": "tester",
             "email": "tester@gmail.com",
@@ -221,7 +226,7 @@ def test_update_admin_invalid_password_and_confirm_dont_match(client):
     )
 
     res = client.put(
-        "/v1/admin/tester@gmail.com",
+        "/api/v1/admins/tester@gmail.com",
         json={
             "name": "tester-different-name",
             "email": "tester@gmail.com",

--- a/api/tests/test_app.py
+++ b/api/tests/test_app.py
@@ -1,10 +1,3 @@
-def test_index(client):
-    response = client.get("/")
-    assert response.status_code == 200
-
-    index = response.get_json()
-    routes = index["routes"]
-    assert len(routes) == 15
 
 
 def test_health(client):

--- a/api/tests/test_app.py
+++ b/api/tests/test_app.py
@@ -1,7 +1,5 @@
-
-
 def test_health(client):
-    response = client.get("/v1/health")
+    response = client.get("/health")
     assert response.status_code == 200
 
     assert response.get_json() == {"msg": "healthy"}

--- a/api/tests/test_culture.py
+++ b/api/tests/test_culture.py
@@ -1,19 +1,19 @@
 def test_list_cultures_empty(client):
-    response = client.get("/v1/culture")
+    response = client.get("/api/v1/cultures")
     assert response.get_json() == {"cultures": []}
 
 
 def test_list_cultures(client):
-    response = client.post("v1/culture", json={"name": "test",},)
+    response = client.post("/api/v1/cultures", json={"name": "test",},)
 
-    response1 = client.get("/v1/culture")
+    response1 = client.get("/api/v1/cultures")
     assert response1.get_json() == {
         "cultures": [{"name": "test", "modified": response.get_json()["modified"]}]
     }
 
 
 def test_create_culture(client):
-    response = client.post("v1/culture", json={"name": "test",},)
+    response = client.post("/api/v1/cultures", json={"name": "test",},)
 
     assert response.status_code == 201
     assert response.get_json()["name"] == "test"
@@ -22,58 +22,58 @@ def test_create_culture(client):
 
 
 def test_create_culture_invalid_400(client):
-    response = client.post("v1/culture", json={"names": "test",},)
+    response = client.post("/api/v1/cultures", json={"names": "test",},)
 
     assert response.status_code == 400
 
 
 def test_create_culture_duplicate(client):
-    response = client.post("v1/culture", json={"name": "test",},)
+    response = client.post("/api/v1/cultures", json={"name": "test",},)
 
     assert response.status_code == 201
 
-    response = client.post("v1/culture", json={"name": "test",},)
+    response = client.post("/api/v1/cultures", json={"name": "test",},)
 
     assert response.status_code == 409
 
 
 def test_delete_culture(client):
-    response = client.post("v1/culture", json={"name": "test",},)
+    response = client.post("/api/v1/cultures", json={"name": "test",},)
 
-    response1 = client.get("/v1/culture")
+    response1 = client.get("/api/v1/cultures")
     assert response1.get_json() == {
         "cultures": [{"name": "test", "modified": response.get_json()["modified"]}]
     }
 
-    response = client.delete("v1/culture/test")
+    response = client.delete("/api/v1/cultures/test")
     assert response.status_code == 200
 
 
 def test_delete_culture_invalid_DNE(client):
-    response = client.delete("v1/culture/test")
+    response = client.delete("/api/v1/cultures/test")
     assert response.status_code == 404
 
 
 def test_get_culture(client):
-    response = client.post("v1/culture", json={"name": "test",},)
+    response = client.post("/api/v1/cultures", json={"name": "test",},)
 
-    test = client.get("/v1/culture/test")
+    test = client.get("/api/v1/cultures/test")
 
     assert test.get_json() == response.get_json()
 
 
 def test_get_culture_invalid_DNE(client):
-    test = client.get("/v1/culture/test1")
+    test = client.get("/api/v1/cultures/test1")
 
     assert test.status_code == 404
 
 
 def test_update_culture(client):
-    response = client.post("v1/culture", json={"name": "test",},)
+    response = client.post("/api/v1/cultures", json={"name": "test",},)
     response_json = response.get_json()
 
     update_response = client.put(
-        "v1/culture/test",
+        "/api/v1/cultures/test",
         json={
             "name": "test",
             "general_insights": [
@@ -101,15 +101,15 @@ def test_update_culture(client):
 
 
 def test_update_culture_invalid_400(client):
-    response = client.post("v1/culture", json={"name": "test",},)
-    update_response = client.put("v1/culture/test", json={"names": "test",},)
+    response = client.post("/api/v1/cultures", json={"name": "test",},)
+    update_response = client.put("/api/v1/cultures/test", json={"names": "test",},)
 
-    update_response.status_code == 400
+    assert update_response.status_code == 400
 
 
 def test_update_culture_create(client):
     update_response = client.put(
-        "v1/culture/test",
+        "/api/v1/cultures/test",
         json={
             "name": "test",
             "general_insights": [
@@ -126,4 +126,4 @@ def test_update_culture_create(client):
         },
     )
 
-    update_response.status_code == 201
+    assert update_response.status_code == 201

--- a/frontend/api/admin.ts
+++ b/frontend/api/admin.ts
@@ -27,7 +27,7 @@ export class Admin {
    * @returns {Promise<string[]>}
    */
   static async get(email: string, token: string): Promise<Admin> {
-    let json = await Api.getAuth(`/admin/${email}`, token);
+    let json = await Api.getAuth(`/admins/${email}`, token);
     return json;
   }
 
@@ -56,7 +56,7 @@ export class Admin {
    * @returns {Promise<string[]>}
    */
   static async list(token: string): Promise<string[]> {
-    let json = await Api.getAuth("/admin", token);
+    let json = await Api.getAuth("/admins", token);
     return json["admins"];
   }
 
@@ -71,7 +71,7 @@ export class Admin {
    * @returns {Promise<void>}
    */
   static async invite(email: string, token: string): Promise<void> {
-    await Api.post("/admin/invite", { email: email }, token);
+    await Api.post("/admins/invite", { email: email }, token);
   }
 
   /**
@@ -91,7 +91,7 @@ export class Admin {
     token: string
   ): Promise<void> {
     await Api.put(
-      `/admin/${this.email}`,
+      `/admins/${this.email}`,
       {
         email: this.email,
         name: this.name,
@@ -113,7 +113,7 @@ export class Admin {
    * @returns {Promise<void>}
    */
   static async delete(email: string, token: string): Promise<void> {
-    await Api.delete(`/admin/${email}`, token);
+    await Api.delete(`/admins/${email}`, token);
   }
 
   /**

--- a/frontend/api/culture.ts
+++ b/frontend/api/culture.ts
@@ -63,7 +63,7 @@ export class Culture {
    * @returns {Promise<Culture>}
    */
   static async get(name: string): Promise<Culture> {
-    let json = await Api.get(`/culture/${name}`);
+    let json = await Api.get(`/cultures/${name}`);
 
     return new this(
       json["name"],
@@ -81,7 +81,7 @@ export class Culture {
    * @returns {Promise<{ name: string; modified: number }[]>}
    */
   static async list(): Promise<{ name: string; modified: number }[]> {
-    let json = await Api.get("/culture");
+    let json = await Api.get("/cultures");
 
     return json["cultures"];
   }
@@ -117,7 +117,7 @@ export class Culture {
    * @returns {Promise<void>}
    */
   static async delete(name: string, token: string): Promise<void> {
-    await Api.delete(`/culture/${name}`, token);
+    await Api.delete(`/cultures/${name}`, token);
   }
 
   /**
@@ -136,6 +136,6 @@ export class Culture {
       name: this.name,
     };
 
-    await Api.put(`/culture/${this.name}`, data, token);
+    await Api.put(`/cultures/${this.name}`, data, token);
   }
 }

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -1,6 +1,6 @@
 import { DefaultTheme } from "react-native-paper";
 
-export const API_URL = "http://localhost:5000/v1";
+export const API_URL = "http://localhost:5000/api/v1";
 
 export const Theme = {
   ...DefaultTheme,


### PR DESCRIPTION
Story: No Story

## Summary

Routes now further conform to RESTful conventions for naming. Possibly letting us render and display pages
from Flask in the future (possibly a Terms of Service or Register admin page). This should be the last time the Api routes have been renamed, and should finalize
version 1. Ideally we don't make any changes to the current routes endpoints.

- Chore(Api): Remove index route
- Chore(Api): routes /v1/... -> /api/v1 and plural
