### PR TITLE
Copy/Open Insight Source

### DIFF
--- a/frontend/views/Culture.tsx
+++ b/frontend/views/Culture.tsx
@@ -1,5 +1,14 @@
 import React, { useState, useEffect } from "react";
-import { StyleSheet, FlatList, SafeAreaView, View } from "react-native";
+import {
+  StyleSheet,
+  FlatList,
+  SafeAreaView,
+  View,
+  Linking,
+  // Clipboard is deprecated, but necessary because of incompatibility with Expo
+  // See https://github.com/react-native-clipboard/clipboard/issues/71#issuecomment-701138494
+  Clipboard,
+} from "react-native";
 
 import {
   getFocusedRouteNameFromRoute,
@@ -15,11 +24,13 @@ import {
   ActivityIndicator,
   IconButton,
   FAB,
+  Divider,
   List,
   Paragraph,
   Button,
   Title,
   Snackbar,
+  Menu,
 } from "react-native-paper";
 
 import {
@@ -450,6 +461,8 @@ type InsightCardProps = {
  */
 function InsightCard(props: InsightCardProps): React.ReactElement {
   const { insight, index, editing, onPress } = props;
+  const [showMenu, setShowMenu] = useState(false);
+  const link = insight.source.data;
 
   return (
     <Card style={Styles.card} onPress={() => editing && onPress(index)}>
@@ -458,7 +471,29 @@ function InsightCard(props: InsightCardProps): React.ReactElement {
         <Paragraph>{insight.information}</Paragraph>
       </Card.Content>
       <Card.Actions>
-        <IconButton icon="link" size={20} />
+        {link && Linking.canOpenURL(link) && (
+          <Menu
+            visible={showMenu}
+            onDismiss={() => setShowMenu(false)}
+            anchor={
+              <IconButton
+                icon="link"
+                size={20}
+                onPress={() => setShowMenu(true)}
+              />
+            }
+          >
+            <Menu.Item
+              title="Copy link"
+              onPress={() => Clipboard.setString(link)}
+            />
+            <Divider />
+            <Menu.Item
+              title="Open link"
+              onPress={() => Linking.openURL(link)}
+            />
+          </Menu>
+        )}
         {editing && (
           <IconButton
             icon="delete"


### PR DESCRIPTION
Story: [OCA-102](https://5911-capstone.atlassian.net/browse/OCA-102)

## Summary

This implementation may seem shortsighted, **it is**, this is because we
don't know the shape of all possible sources for an insight or what they will be in the
future, so this solution works with our current example data, but not
all possible values.

This implementation uses the deprecated ["React-native" Clipboard](https://reactnative.dev/docs/clipboard), this is because Expo
doesn't currently support the community version that the core React Native version was deprecated in favor of. See [issue](https://github.com/react-native-clipboard/clipboard/issues/71#issuecomment-701138494).

Fixed bug where Link icon would be displayed even though an insight had no sources. Hopefully not a thing in the future, but right now it is so :man_shrugging: 

## Screenshots

![windowshot-11-23-2020-10:46:51 PM](https://user-images.githubusercontent.com/31719071/100044772-cde08d80-2ddd-11eb-9534-01d675b40ab2.png)